### PR TITLE
fix: cleanup candidate_running.conf after it's loaded

### DIFF
--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -143,6 +143,9 @@ class VyOSDriver(NetworkDriver):
             match_notchanged = re.findall("No configuration changes to commit", output_loadcmd)
             match_failed = re.findall("Failed to parse specified config file", output_loadcmd)
 
+            # Clean up candidate configuration
+            self.device.send_command("rm -f "+self._DEST_FILENAME)
+
             if match_failed:
                 raise ReplaceConfigException("Failed replace config: "
                                              + output_loadcmd)


### PR DESCRIPTION
When the rendered file is scp'd to the device, it's set to be owned by the user that did it, this makes it so if another users tries to do it, they get a permission denied error because they cannot overwrite the `candidate_running.conf` file.

```
fatal: [router1]: FAILED! => changed=false 
  msg: |-
    cannot load config: scp: /var/tmp/candidate_running.conf: Permission denied
```

This seems to be because the `/var/tmp/candidate_running.conf` file is left around from previous runs and has 644 permissions, only allowing the vyos user to write to it. This wouldn't become an issue if these files were cleaned up after the operation(s) are finished, which it seems the code as of now does not do that.

```
vyos@dev:~$ ls -la /var/tmp
total 20
drwxrwxrwt  6 root  root   180 Jun 11 16:50 .
drwxr-xr-x  1 root  
-rwxr-xr-x  1 vyos  users 1896 Jun 11 16:48 backup_running.conf
-rw-r--r--  1 vyos  users 1784 Jun 11 16:48 candidate_running.conf
-rw-r--r--  1 yzguy users  182 Jun 11 16:50 test.sh
```

This change removes this file after it's loaded into configure mode

Fixes https://github.com/napalm-automation-community/napalm-vyos/issues/46
