### PR TITLE
feat: add additional available netmiko arguments

### DIFF
--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -73,6 +73,9 @@ class VyOSDriver(NetworkDriver):
             'alt_host_keys': False,
             'alt_key_file': '',
             'ssh_config_file': None,
+            'session_log': None,
+            'fast_cli': True,
+            'read_timeout_override': None
         }
 
         fields = netmiko_version.split('.')


### PR DESCRIPTION
Add a few additional netmiko arguments to help debugging/read timeout

* session_log - allows you to specify a file netmiko will log to
* fast_cli - allows you to tell Netmiko to not modify the global_delay_factor to .1
* read_timeout_override - allow you to globally override read time outs for send_command (https://pynet.twb-tech.com/blog/netmiko-read-timeout.html)