### PR TITLE
refactor: revert #4, remove read_timeout from send_config_set

### DIFF
--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -141,7 +141,7 @@ class VyOSDriver(NetworkDriver):
         if os.path.exists(cfg_filename) is True:
             self._scp_client.scp_transfer_file(cfg_filename, self._DEST_FILENAME)
             self.device.send_command("cp "+self._BOOT_FILENAME+" "+self._BACKUP_FILENAME)
-            output_loadcmd = self.device.send_config_set(['load '+self._DEST_FILENAME], read_timeout=60)
+            output_loadcmd = self.device.send_config_set(['load '+self._DEST_FILENAME])
             match_loaded = re.findall("Load complete.", output_loadcmd)
             match_notchanged = re.findall("No configuration changes to commit", output_loadcmd)
             match_failed = re.findall("Failed to parse specified config file", output_loadcmd)


### PR DESCRIPTION
Revert #4

We do not need to set an explicit read_timeout on the send_config_set method, it will take in account the `read_timeout_override` parameter